### PR TITLE
Remove unused flags from docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ sentryout --project 'my project' --message 'my message here' --command 'echo "ms
 For the full list of options use the `--help` flag:
 ```
 usage: to_sentry [-h] -p PROJECT -m MSG -e CMD [-c PATH]
-                 [--ignore-environment] [--ignore-exitcode] [--ignore-stderr]
-                 [--ignore-stdout] [-v]
+                 [--ignore-exitcode] [-v]
 
 dump command line sentry logger
 
@@ -47,10 +46,7 @@ optional arguments:
   -e CMD, --cmd CMD     bash command or script to execute
   -c PATH, --config PATH
                         location of Sentry configuration file
-  --ignore-environment  do not send environment variables to sentry
   --ignore-exitcode     send results to sentry regardless of exit code
-  --ignore-stderr       do not send stderr output to sentry
-  --ignore-stdout       do not send stdout output to sentry
   -v, --version         show program's version number and exit
 ```
 


### PR DESCRIPTION
Commit 62dda329da025d31bb50d440238b2a08c1a67d47 removed the `--ignore-stderr`, `--ignore-stdout`, and `--ignore-environment` flags but they're still part of the docs. I don't see a reason I would need them. I think it's fine to simplify the options and remove them.